### PR TITLE
Fix: Dark mode color input background

### DIFF
--- a/components/input-color-picker.tsx
+++ b/components/input-color-picker.tsx
@@ -53,7 +53,7 @@ export default function InputColorPicker({ id, field, colorHsl }: IProps) {
               readOnly
               type="text"
               value={colorPicker ? colorPicker : "#ffffff"}
-              className="w-full outline-none uppercase cursor-pointer"
+              className="w-full outline-none uppercase cursor-pointer bg-transparent"
               // only hex = uppercase
             />
           </div>


### PR DESCRIPTION
Just wanted to say great work! This is something that I didn't know that I needed :)

Wanted to throw in a quick fix to this visual issue in dark mode:

Current State:
![image](https://github.com/mickasmt/ui-colorgen/assets/7144617/4172c482-a4f6-41dc-b03c-57ba388016b3)

After:
![image](https://github.com/mickasmt/ui-colorgen/assets/7144617/2084fa78-c323-41ac-bb1c-2cd36013b37e)
